### PR TITLE
Add .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 2
+    commit-message:
+      # Skip CI when updating, well, CI.
+      # See: https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
+      prefix: '[skip ci] '
+    schedule:
+      time: "10:00"
+      timezone: "America/New_York"
+      interval: "daily"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    open-pull-requests-limit: 10
+    schedule:
+      time: "10:00"
+      timezone: "America/New_York"
+      interval: "daily"


### PR DESCRIPTION
`dependabot` is an advantageous CI/CD automation provided by GitHub. It opens PRs to update older dependencies and alerts on known vulnerabilities in the software supply chain.

It's a handy bedrock to have in any repository workflow.

https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide

I have configured this for a daily 10:00 AM `America/New_York` schedule; however, this can be adjusted to more appropriately match your personal schedule.