### PR TITLE
Use mermaid for the Juju objects graph in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,27 +5,15 @@
 Jockey is a CLI tool designed to facilitate quick and easy retrieval of Juju objects using filters.  It uses automatic caching of Juju's status in json format to enable faster parsing.  
 
 Jockey relies on this model of Juju objects and how they are related:
+```mermaid
+flowchart
+    C[Charm] --> A(Application)
+    A -->|Instances of| U[Unit]
+    U -->|Running on| M[Machine]
+    M -->|Metadata| M_I[IP]
+    M -->|Metadata| M_H[Hostname]
 ```
-+-------+
-| Charm |
-+-------+
-    |
-+-------------+
-| Application |
-+-------------+
-    |
-+------+
-| Unit |
-+------+
-    |
-+---------+
-| Machine |------\
-+---------+      |
-    |            |
-+----------+   +----+
-| Hostname |   | IP |
-+----------+   +----+
-```
+
 All filtering actions are performed by navigating this tree.
 
 ## Command Anatomy

--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@ Jockey is a CLI tool designed to facilitate quick and easy retrieval of Juju obj
 
 Jockey relies on this model of Juju objects and how they are related:
 ```mermaid
-flowchart
-    C[Charm] --> A(Application)
+---
+title: Juju object relationships
+---
+flowchart LR
+    C([Charm]) --> A[Application]
     A -->|Instances of| U[Unit]
     U -->|Running on| M[Machine]
-    M -->|Metadata| M_I[IP]
-    M -->|Metadata| M_H[Hostname]
+    M -->|Metadata| M_I(IP)
+    M -->|Metadata| M_H(Hostname)
 ```
 
 All filtering actions are performed by navigating this tree.


### PR DESCRIPTION
This PR uses a relatively new feature in GitHub: diagramming.
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams

I've opted to reformat the text-based diagram in `README.md` as a [mermaid flowchart](https://mermaid.js.org/syntax/flowchart.html). 
To aid with any tweaks, there is an [online tool to test changes](https://mermaid.live/edit#pako:eNp1j0FrhDAQhf9KyElh_QMeCrI9rKVC2eLJLGUaR83WTCSZUMq6_71Z67Vzmnnvew_mJrXrUZayKApFbHjGUrzEaxTu84qahccZ2DgKk1mCog0bZvetJ_AsXs-KRJpj1h2TYC-5KIonUXXVssxGb8nLH1I9nLWmwEAag3DDKtquJcM70G7AORIZGoWjVTRdA3oyhDvRbESDDD0wJP-jzuq3_D_zlJ1cYAKLuTxIi96C6dOrt0dASZ7QopJlWnvwX0oquicOIrv3H9KyZB_xIL2L4yTLAeaQrrikdnw2MHqwu3r_BZuRaqw).

A preview of the README.md can be found on my fork:
https://github.com/johnlettman/pr-jockey/tree/doc/mermaid?tab=readme-ov-file#readme

