### PR TITLE
Add new schema-based types workflow for Juju objects

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "scripts/schemagen"]
+	path = scripts/schemagen
+	url = https://github.com/juju/schemagen.git

--- a/scripts/update_juju_schema
+++ b/scripts/update_juju_schema
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""
+A tool for updating the strong Python typing for Juju by processing the output from the schemagen project.
+"""
+
+__author__ = "John Lettman"
+__email__ = "the@johnlettman.com"
+__license__ = "MIT"
+
+import json
+import logging
+import os
+import random
+import re
+import sys
+from argparse import Namespace, ArgumentParser
+from subprocess import Popen, PIPE
+from tempfile import TemporaryDirectory
+from typing import Optional, Any, Dict, Generator, NamedTuple, cast, Union
+
+import jsonschema_gentypes
+from jsonschema_gentypes import jsonschema_draft_04, jsonschema_draft_2019_09_meta_data, normalize
+from jsonschema_gentypes.api import API
+from jsonschema_gentypes.api_draft_04 import APIv4
+from jsonschema_gentypes.api_draft_2019_09 import APIv201909
+from jsonschema_gentypes.cli import process_config
+from jsonschema_gentypes.configuration import Configuration, GenerateItem
+
+DEFAULT_ALLOW_LIST = ["full_status"]
+
+SCHEMA_HEADER = "https://json-schema.org/draft/2020-12/schema"
+
+SCRIPTS_DIR = os.path.dirname(os.path.realpath(__file__))
+SCHEMAGEN_DIR = os.path.join(SCRIPTS_DIR, "schemagen")
+REPO_DIR = os.path.dirname(SCRIPTS_DIR)
+OUTPUT_DIR = os.path.join(REPO_DIR, "src", "jockey", "juju_schema")
+
+SCHEMAGEN = "schemagen.go"
+
+LOGGING_LEVELS = {
+    0: logging.ERROR,
+    1: logging.WARN,
+    2: logging.INFO,
+    3: logging.DEBUG,
+}
+
+logger = logging.getLogger(__name__)
+
+
+class DefinitionResult(NamedTuple):
+    title: str
+    module_name: str
+    output_module_name: str
+    output_module_path: str
+    output_file_name: str
+    output_file_path: str
+
+
+def new_ref_to_proposed_name(self, ref: str) -> str:
+    logger.debug("Overriding (new_ref_to_proposed_name) name mangling on %s", ref)
+    ref_proposed_name = ref
+
+    if ref.startswith("#/$defs/"):
+        ref_proposed_name = ref[len("#/$defs/"):]
+    elif ref.startswith("#/"):
+        ref_proposed_name = ref[len("#/"):]
+    if "/" in ref_proposed_name:
+        ref_proposed_name = ref_proposed_name.replace("/", " ")
+
+    return ref_proposed_name
+
+
+def new_get_name(
+        schema: Optional[
+            Union[
+                jsonschema_draft_04.JSONSchemaD4,
+                jsonschema_draft_2019_09_meta_data.JSONSchemaItemD2019,
+            ]
+        ],
+        proposed_name: Optional[str] = None,
+        _1: bool = True,
+        _2: Optional[str] = None,
+        postfix: Optional[str] = None,
+) -> str:
+    # Get the base name
+    has_title = isinstance(schema, dict) and "title" in schema
+    name = schema["title"] if has_title else proposed_name  # type: ignore
+    assert name is not None
+    name = normalize(name) # type: ignore
+
+    prefix = "" if has_title else "_"
+    rand = str(random.randint(0, 9999)) if name != "Root" else ""  # nosec
+
+    logger.debug("Overriding (new_get_name) name mangling on %s", name)
+    output = prefix + "".join([char for char in name if not char.isspace()])
+
+    if postfix:
+        output += postfix
+    if not jsonschema_gentypes.get_name.__dict__.get("names"):
+        jsonschema_gentypes.get_name.__dict__["names"] = set()
+    elif output in jsonschema_gentypes.get_name.__dict__["names"]:
+        output += rand
+    jsonschema_gentypes.get_name.__dict__["names"].add(output)
+    return output
+
+def new_api_get_name(
+    self,
+    schema: Optional[
+        Union[
+            jsonschema_draft_04.JSONSchemaD4,
+            jsonschema_draft_2019_09_meta_data.JSONSchemaItemD2019,
+        ]
+    ],
+    proposed_name: Optional[str] = None,
+    upper: bool = False,
+    postfix: Optional[str] = None,
+) -> str:
+    return new_get_name(schema, proposed_name, upper, self.get_name_properties, postfix=postfix)
+
+API.get_name = new_api_get_name
+APIv201909.ref_to_proposed_name = new_ref_to_proposed_name
+APIv4.ref_to_proposed_name = new_ref_to_proposed_name
+jsonschema_gentypes.get_name = new_get_name
+
+
+def schemagen() -> Any:
+    command = ['go', 'run', SCHEMAGEN]
+    logger.info("Running schemagen: %s", command)
+
+    process = Popen(command, cwd=SCHEMAGEN_DIR, stdout=PIPE)
+    output = json.load(process.stdout)
+    logger.debug("Obtained schemagen output: %s", output)
+    return output
+
+
+def camel_to_snake(name: str) -> str:
+    name = re.sub('([a-z0-9])([A-Z])', r'\1_\2', name)
+    name = re.sub('([A-Z]+)([A-Z][a-z])', r'\1_\2', name)
+    return name.lower()
+
+
+def merge_definitions(output: Any) -> Dict[str, Any]:
+    definitions = {}
+
+    for item in output:
+        if "Schema" in item and "definitions" in item["Schema"]:
+            definitions.update(item["Schema"]["definitions"])
+
+    return definitions
+
+
+def emit_definitions(definitions: Dict[str, Any], output_dir: str) -> Generator[DefinitionResult, None, None]:
+    for key, value in definitions.items():
+        module_name = camel_to_snake(key)
+
+        output_module_name = module_name + ".py"
+        output_module_path = os.path.join(OUTPUT_DIR, output_module_name)
+
+        output_file_name = module_name + ".json"
+        output_file_path = os.path.join(output_dir, output_file_name)
+
+        schema = {
+            "$schema": SCHEMA_HEADER,
+            "title": key,
+            "definitions": {
+                k: {
+                    "type": "object",
+                    "$ref": f"{os.path.join(output_dir, camel_to_snake(k) + '.json')}"
+                } for k in definitions
+            },
+            **value
+        }
+
+        with open(output_file_path, "w") as f:
+            logger.info("Emitting %s", output_file_name)
+            json.dump(schema, f, indent=4)
+
+        yield DefinitionResult(key, module_name, output_module_name, output_module_path, output_file_name,
+                               output_file_path)
+
+
+def parse_args(argv: Optional[list[str]]) -> Namespace:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    parser = ArgumentParser(prog="update_juju_schema", description=__doc__)
+    parser.add_argument("-v", "--verbose", dest="verbosity", action="count", default=0,
+                        help="Verbosity (between 1-4 occurrences with more leading to more "
+                             "verbose logging). CRITICAL=0, ERROR=1, WARN=2, INFO=3, "
+                             "DEBUG=4")
+
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+    logging.basicConfig(level=LOGGING_LEVELS[args.verbosity])
+
+    output = schemagen()
+    merged = merge_definitions(output)
+
+    with TemporaryDirectory() as temp_dir:
+        logger.info("Working in %s", temp_dir)
+        results = list(emit_definitions(merged, temp_dir))
+
+        emitted_file_paths = map(lambda result: result.output_file_path, results)
+        filtered_results = filter(
+            lambda result: result.title in DEFAULT_ALLOW_LIST or result.module_name in DEFAULT_ALLOW_LIST,
+            results)
+        generate = map(lambda result: cast(GenerateItem, {
+            "source": result.output_file_path,
+            "destination": result.output_module_path,
+        }), filtered_results)
+
+        config: Configuration = {"generate": list(generate)}
+        logger.info("Using configuration %s", config)
+
+        logger.info("Writing to %s", OUTPUT_DIR)
+        os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+        process_config(config, list(emitted_file_paths))
+
+    return 0
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/src/jockey/juju_schema/full_status.py
+++ b/src/jockey/juju_schema/full_status.py
@@ -1,0 +1,398 @@
+from typing import Any, Dict, List, TypedDict
+from typing_extensions import Required
+
+
+# | ApplicationOfferStatus.
+ApplicationOfferStatus = TypedDict('ApplicationOfferStatus', {
+    # | Required property
+    'active-connected-count': Required[int],
+    # | Required property
+    'application-name': Required[str],
+    # | Required property
+    'charm': Required[str],
+    # | Required property
+    'endpoints': Required[Dict[str, "RemoteEndpoint"]],
+    # | Error.
+    'err': "Error",
+    # | Required property
+    'offer-name': Required[str],
+    # | Required property
+    'total-connected-count': Required[int],
+}, total=False)
+
+
+# | ApplicationStatus.
+ApplicationStatus = TypedDict('ApplicationStatus', {
+    # | Required property
+    'can-upgrade-to': Required[str],
+    # | Required property
+    'charm': Required[str],
+    'charm-channel': str,
+    # | Required property
+    'charm-profile': Required[str],
+    # | Required property
+    'charm-version': Required[str],
+    # | Required property
+    'endpoint-bindings': Required[Dict[str, str]],
+    # | Error.
+    'err': "Error",
+    # | Required property
+    'exposed': Required[bool],
+    'exposed-endpoints': Dict[str, "ExposedEndpoint"],
+    'int': int,
+    # | Value.
+    # | 
+    # | Required property
+    'life': Required["Value"],
+    # | Required property
+    'meter-statuses': Required[Dict[str, "MeterStatus"]],
+    'provider-id': str,
+    # | Required property
+    'public-address': Required[str],
+    # | Required property
+    'relations': Required[Dict[str, List[str]]],
+    # | Required property
+    'series': Required[str],
+    # | DetailedStatus.
+    # | 
+    # | Required property
+    'status': Required["DetailedStatus"],
+    # | Required property
+    'subordinate-to': Required[List[str]],
+    # | Required property
+    'units': Required[Dict[str, "UnitStatus"]],
+    # | Required property
+    'workload-version': Required[str],
+}, total=False)
+
+
+# | BranchStatus.
+BranchStatus = TypedDict('BranchStatus', {
+    # | Required property
+    'assigned-units': Required[Dict[str, List[str]]],
+    # | Required property
+    'created': Required[int],
+    # | Required property
+    'created-by': Required[str],
+}, total=False)
+
+
+class DetailedStatus(TypedDict, total=False):
+    """ DetailedStatus. """
+
+    data: Required[Dict[str, Dict[str, Any]]]
+    """ Required property """
+
+    err: "Error"
+    """ Error. """
+
+    info: Required[str]
+    """ Required property """
+
+    kind: Required[str]
+    """ Required property """
+
+    life: Required["Value"]
+    """
+    Value.
+
+    Required property
+    """
+
+    since: Required[str]
+    """
+    format: date-time
+
+    Required property
+    """
+
+    status: Required[str]
+    """ Required property """
+
+    version: Required[str]
+    """ Required property """
+
+
+
+class EndpointStatus(TypedDict, total=False):
+    """ EndpointStatus. """
+
+    application: Required[str]
+    """ Required property """
+
+    name: Required[str]
+    """ Required property """
+
+    role: Required[str]
+    """ Required property """
+
+    subordinate: Required[bool]
+    """ Required property """
+
+
+
+class Error(TypedDict, total=False):
+    """ Error. """
+
+    code: Required[str]
+    """ Required property """
+
+    info: Dict[str, Dict[str, Any]]
+    message: Required[str]
+    """ Required property """
+
+
+
+# | ExposedEndpoint.
+ExposedEndpoint = TypedDict('ExposedEndpoint', {
+    'expose-to-cidrs': List[str],
+    'expose-to-spaces': List[str],
+}, total=False)
+
+
+# | FullStatus.
+FullStatus = TypedDict('FullStatus', {
+    # | Required property
+    'applications': Required[Dict[str, "ApplicationStatus"]],
+    # | Required property
+    'branches': Required[Dict[str, "BranchStatus"]],
+    # | format: date-time
+    # | 
+    # | Required property
+    'controller-timestamp': Required[str],
+    # | Required property
+    'machines': Required[Dict[str, "MachineStatus"]],
+    # | ModelStatusInfo.
+    # | 
+    # | Required property
+    'model': Required["ModelStatusInfo"],
+    # | Required property
+    'offers': Required[Dict[str, "ApplicationOfferStatus"]],
+    # | Required property
+    'relations': Required[List["RelationStatus"]],
+    # | Required property
+    'remote-applications': Required[Dict[str, "RemoteApplicationStatus"]],
+}, total=False)
+
+
+class LXDProfile(TypedDict, total=False):
+    """ LXDProfile. """
+
+    config: Required[Dict[str, str]]
+    """ Required property """
+
+    description: Required[str]
+    """ Required property """
+
+    devices: Required[Dict[str, Dict[str, str]]]
+    """ Required property """
+
+
+
+# | MachineStatus.
+MachineStatus = TypedDict('MachineStatus', {
+    # | DetailedStatus.
+    # | 
+    # | Required property
+    'agent-status': Required["DetailedStatus"],
+    # | Required property
+    'constraints': Required[str],
+    # | Required property
+    'containers': Required[Dict[str, "MachineStatus"]],
+    # | Required property
+    'display-name': Required[str],
+    # | Required property
+    'dns-name': Required[str],
+    # | Required property
+    'hardware': Required[str],
+    # | Required property
+    'has-vote': Required[bool],
+    'hostname': str,
+    # | Required property
+    'id': Required[str],
+    # | Required property
+    'instance-id': Required[str],
+    # | DetailedStatus.
+    # | 
+    # | Required property
+    'instance-status': Required["DetailedStatus"],
+    'ip-addresses': List[str],
+    # | Required property
+    'jobs': Required[List[str]],
+    'lxd-profiles': Dict[str, "LXDProfile"],
+    # | DetailedStatus.
+    # | 
+    # | Required property
+    'modification-status': Required["DetailedStatus"],
+    'network-interfaces': Dict[str, "NetworkInterface"],
+    'primary-controller-machine': bool,
+    # | Required property
+    'series': Required[str],
+    # | Required property
+    'wants-vote': Required[bool],
+}, total=False)
+
+
+class MeterStatus(TypedDict, total=False):
+    """ MeterStatus. """
+
+    color: Required[str]
+    """ Required property """
+
+    message: Required[str]
+    """ Required property """
+
+
+
+# | ModelStatusInfo.
+ModelStatusInfo = TypedDict('ModelStatusInfo', {
+    # | Required property
+    'available-version': Required[str],
+    # | Required property
+    'cloud-tag': Required[str],
+    # | MeterStatus.
+    # | 
+    # | Required property
+    'meter-status': Required["MeterStatus"],
+    # | DetailedStatus.
+    # | 
+    # | Required property
+    'model-status': Required["DetailedStatus"],
+    # | Required property
+    'name': Required[str],
+    'region': str,
+    # | Required property
+    'sla': Required[str],
+    # | Required property
+    'type': Required[str],
+    # | Required property
+    'version': Required[str],
+}, total=False)
+
+
+# | NetworkInterface.
+NetworkInterface = TypedDict('NetworkInterface', {
+    'dns-nameservers': List[str],
+    'gateway': str,
+    # | Required property
+    'ip-addresses': Required[List[str]],
+    # | Required property
+    'is-up': Required[bool],
+    # | Required property
+    'mac-address': Required[str],
+    'space': str,
+}, total=False)
+
+
+class RelationStatus(TypedDict, total=False):
+    """ RelationStatus. """
+
+    endpoints: Required[List["EndpointStatus"]]
+    """ Required property """
+
+    id: Required[int]
+    """ Required property """
+
+    interface: Required[str]
+    """ Required property """
+
+    key: Required[str]
+    """ Required property """
+
+    scope: Required[str]
+    """ Required property """
+
+    status: Required["DetailedStatus"]
+    """
+    DetailedStatus.
+
+    Required property
+    """
+
+
+
+# | RemoteApplicationStatus.
+RemoteApplicationStatus = TypedDict('RemoteApplicationStatus', {
+    # | Required property
+    'endpoints': Required[List["RemoteEndpoint"]],
+    # | Error.
+    'err': "Error",
+    # | Value.
+    # | 
+    # | Required property
+    'life': Required["Value"],
+    # | Required property
+    'offer-name': Required[str],
+    # | Required property
+    'offer-url': Required[str],
+    # | Required property
+    'relations': Required[Dict[str, List[str]]],
+    # | DetailedStatus.
+    # | 
+    # | Required property
+    'status': Required["DetailedStatus"],
+}, total=False)
+
+
+class RemoteEndpoint(TypedDict, total=False):
+    """ RemoteEndpoint. """
+
+    interface: Required[str]
+    """ Required property """
+
+    limit: Required[int]
+    """ Required property """
+
+    name: Required[str]
+    """ Required property """
+
+    role: Required[str]
+    """ Required property """
+
+
+
+# | UnitStatus.
+UnitStatus = TypedDict('UnitStatus', {
+    'address': str,
+    # | DetailedStatus.
+    # | 
+    # | Required property
+    'agent-status': Required["DetailedStatus"],
+    # | Required property
+    'charm': Required[str],
+    'leader': bool,
+    # | Required property
+    'machine': Required[str],
+    # | Required property
+    'opened-ports': Required[List[str]],
+    'provider-id': str,
+    # | Required property
+    'public-address': Required[str],
+    # | Required property
+    'subordinates': Required[Dict[str, "UnitStatus"]],
+    # | DetailedStatus.
+    # | 
+    # | Required property
+    'workload-status': Required["DetailedStatus"],
+    # | Required property
+    'workload-version': Required[str],
+}, total=False)
+
+
+# | Value.
+Value = TypedDict('Value', {
+    'allocate-public-ip': bool,
+    'arch': str,
+    'container': str,
+    'cores': int,
+    'cpu-power': int,
+    'instance-role': str,
+    'instance-type': str,
+    'mem': int,
+    'root-disk': int,
+    'root-disk-source': str,
+    'spaces': List[str],
+    'tags': List[str],
+    'virt-type': str,
+    'zones': List[str],
+}, total=False)


### PR DESCRIPTION
This PR implements a workflow to generate Python types from the generated Juju JSON schema. This helps enforce strong typing and consistency for JSON objects like Juju status, machines, charms, etc.

![image](https://github.com/user-attachments/assets/b9f6cdf9-92f0-4667-b04c-6a03b720416a)
![image](https://github.com/user-attachments/assets/69078157-061a-4719-82b4-68747424ced0)
