### PR TITLE
Add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help improve Jockey
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+## Describe the Bug
+*What went wrong?*
+
+## Steps to Reproduce
+1.
+2.
+3.
+
+## Expected Behavior
+*What should have happened?*
+
+## Screenshots/Logs
+*(Optional) Add screenshots or logs to help explain the issue.*
+
+## Environment
+- **Operating system:**  
+- **Python version:** 
+- **Juju version:**  
+
+## Additional Context
+*(Optional) Any other details?*

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest a feature for Jockey
+title: 'Feature: '
+labels: 'enhancement'
+assignees: ''
+
+---
+
+## Problem
+*Briefly describe the problem or need.*
+
+## Proposed Feature
+*What would you like to see added?*
+
+## Additional Context
+*(Optional) Any extra details or screenshots.*

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Description
+*Provide a detailed explanation of the changes you have made.
+Include the reasons behind these changes and any relevant context.
+Link any related issues.*
+
+## Type of Change
+- [ ] New feature
+- [ ] Bug fix
+- [ ] Documentation update
+- [ ] Refactoring
+- [ ] Hotfix
+- [ ] Security fix
+
+## Testing
+*Detail the testing you have performed to ensure that these changes function as intended.*
+
+## Impact
+*Discuss the impact of your changes on the project.
+This might include effects on performance, new dependencies, or changes in behaviour.*
+
+## Additional Information
+*Any additional information that reviewers should be aware of.*
+
+## Checklist
+- [ ] I have documented my code with docstrings and comments, particularly in hard-to-understand areas.
+- [ ] My changes adhere to the coding and style guidelines of the project and pass linting.
+- [ ] My changes generate no new warnings.


### PR DESCRIPTION
This PR adds simple GitHub templates for issue reporting and PRs.
They can help move things along and set expectations for bug reporting or documenting PRs.

Please review before merge to see whether they fit the overall vibe. :)