### PR TITLE
Snap: use strict confinement (fix #48)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -7,15 +7,34 @@ description: |
   It uses automatic caching of Juju's status in json format to enable faster parsing.
 license: MIT
 grade: stable
-confinement: classic
+confinement: strict
 
 architectures: [amd64, i386, arm64, armhf, ppc64el]
+
+plugs:
+  juju-bin:
+    interface: content
+    content: juju-bin
+    target: $SNAP/usr/juju
+    default-provider: juju
+  dot-local-share-juju:
+    interface: personal-files
+    read:
+      - $HOME/.local/share/juju
+      - $HOME/.local/share/juju/ssh
+      - $HOME/.local/share/juju/lxd
+    write:
+      - $HOME/.local/share/juju/cookies
 
 apps:
   juju-jockey:
     command: bin/juju-jockey
     plugs:
+      - juju-bin
+      - dot-local-share-juju
       - home
+      - ssh-keys
+      - network
 
 parts:
   juju-jockey:

--- a/src/jockey/__main__.py
+++ b/src/jockey/__main__.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Jockey: a Juju query language to put all of your Juju objects at your fingertips."""
+from argparse import ArgumentParser, FileType, Namespace
 import os
 import sys
-from argparse import ArgumentParser, FileType, Namespace
 from typing import Optional, Sequence
 
 from jockey.__init__ import __version__ as version
@@ -16,6 +16,7 @@ from jockey.core import (
     parse_filter_string,
 )
 from jockey.status_keeper import cache_juju_status, read_local_juju_status_file, retrieve_juju_cache
+
 
 if "SNAP" in os.environ:
     os.environ["PATH"] += ":" + os.path.join(os.environ["SNAP"], "usr", "juju", "bin")

--- a/src/jockey/__main__.py
+++ b/src/jockey/__main__.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Jockey: a Juju query language to put all of your Juju objects at your fingertips."""
-from argparse import ArgumentParser, FileType, Namespace
+import os
 import sys
+from argparse import ArgumentParser, FileType, Namespace
 from typing import Optional, Sequence
 
 from jockey.__init__ import __version__ as version
@@ -15,6 +16,9 @@ from jockey.core import (
     parse_filter_string,
 )
 from jockey.status_keeper import cache_juju_status, read_local_juju_status_file, retrieve_juju_cache
+
+if "SNAP" in os.environ:
+    os.environ["PATH"] += ":" + os.path.join(os.environ["SNAP"], "usr", "juju", "bin")
 
 
 INFO_MESSAGE = f"""


### PR DESCRIPTION
## Description
Fixes #48. Moves the snap to `strict` confinement with tight coupling with the Juju snap.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [x] Security fix

## Testing
- Installed and tested new snap
- Invoked snap environment to test `juju` from within
- Checked edge-cases

## Impact
Snap `strict` confinement requires the following interfaces until it's on Snap Store:

```bash
sudo snap connect juju-jockey:juju-bin juju:juju-bin
for x in dot-local-share-juju home ssh-keys network; do
  sudo snap connect "juju-jockey:${x}"
done
```

## Checklist
- [x] I have documented my code with docstrings and comments, particularly in hard-to-understand areas.
- [x] My changes adhere to the coding and style guidelines of the project and pass linting.
- [x] My changes generate no new warnings.
