### PR TITLE
Fix #56, pass `mypy`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ wheels/
 *.egg
 MANIFEST
 setup.py
+__pycache__/
 
 # Installer logs
 pip-log.txt

--- a/poetry.lock
+++ b/poetry.lock
@@ -662,14 +662,14 @@ files = [
 ]
 
 [[package]]
-name = "dotty-dict"
-version = "1.3.1"
-description = "Dictionary wrapper for quick access to deeply nested keys."
+name = "dotty-dictionary"
+version = "1.2.0"
+description = "Dictionary wrapper that provides dot notation access to nested dictionaries"
 optional = false
-python-versions = ">=3.5,<4.0"
+python-versions = ">=3.10,<4.0"
 files = [
-    {file = "dotty_dict-1.3.1-py3-none-any.whl", hash = "sha256:5022d234d9922f13aa711b4950372a06a6d64cb6d6db9ba43d0ba133ebfce31f"},
-    {file = "dotty_dict-1.3.1.tar.gz", hash = "sha256:4b016e03b8ae265539757a53eba24b9bfda506fb94fbce0bee843c6f05541a15"},
+    {file = "dotty_dictionary-1.2.0-py3-none-any.whl", hash = "sha256:9a763d7a5146975ef03e5aa2b978aee43df97140adad9fee4c68f6d80fd36fbb"},
+    {file = "dotty_dictionary-1.2.0.tar.gz", hash = "sha256:035873367519439ab17af8a1b1fe84bd8bf3e7da77f2521c49e86f32c4bcc03a"},
 ]
 
 [[package]]
@@ -2410,6 +2410,31 @@ datetime = ["packaging", "python-dateutil (>=2.8.0,<3.0.0)", "pytz (>=2018.9)"]
 test = ["packaging", "pytest (>=6.0.1)", "python-dateutil (>=2.8.0,<3.0.0)", "pytz (>=2018.9)", "tcolorpy"]
 
 [[package]]
+name = "types-paramiko"
+version = "3.4.0.20240423"
+description = "Typing stubs for paramiko"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "types-paramiko-3.4.0.20240423.tar.gz", hash = "sha256:aaa98dda232c47886563d66743d3a8b66c432790c596bc3bdd3f17f91be2a8c1"},
+    {file = "types_paramiko-3.4.0.20240423-py3-none-any.whl", hash = "sha256:c56e0d43399a1b909901b1e0375e0ff6ee62e16cd6e00695024abc2e9fe02035"},
+]
+
+[package.dependencies]
+cryptography = ">=37.0.0"
+
+[[package]]
+name = "types-regex"
+version = "2024.7.24.20240726"
+description = "Typing stubs for regex"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "types-regex-2024.7.24.20240726.tar.gz", hash = "sha256:f9cbebe607f53860bf5979de1e2a80cc04faf4849ee324461f982a3d46276d76"},
+    {file = "types_regex-2024.7.24.20240726-py3-none-any.whl", hash = "sha256:c436d7eace8e6c33cec31630135c804c15cd4ef110baf9cdd370ac6e376ff661"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -2569,4 +2594,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "fcf96004a84af4a5040db59c41b59730fd94ff9f052f99be7a90fb6a991c3a7a"
+content-hash = "9cea5cdbac8d9019ac04834202142490f9f4c207c4415ce44d2681866f609ef2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ xdgenvpy = "^2.4.0"
 python-slugify = "^8.0.4"
 rich-argparse = "^1.5.2"
 regex = "^2024.7.24"
-dotty-dict = "^1.3.1"
+dotty-dictionary = "^1.2.0"
 
 [tool.poetry.group.dev.dependencies]
 isort = "^5.12.0"
@@ -56,6 +56,8 @@ myst-parser = "^4.0.0"
 canonical-sphinx = "^0.1.0"
 sphinx-autodoc-typehints = "^2.3.0"
 sphinx-autoapi = "^3.3.1"
+types-paramiko = "^3.4.0.20240423"
+types-regex = "^2024.7.24.20240726"
 
 [tool.coverage.run]
 branch = true

--- a/src/jockey/__args__.py
+++ b/src/jockey/__args__.py
@@ -5,22 +5,17 @@ from typing import Optional, Sequence
 
 logger = getLogger(__name__)
 
-try:
-    from rich_argparse import ArgumentDefaultsRichHelpFormatter as ArgumentDefaultsHelpFormatter
+from rich_argparse import ArgumentDefaultsRichHelpFormatter as ArgumentDefaultsHelpFormatter
 
-    from jockey import __issues__, __repository__, __version__
+from jockey import __issues__, __repository__, __version__
 
-    epilog = (
-        f"[grey50]Version {__version__}[/] | "
-        f"[dark_cyan][link={__repository__}]{__repository__}[/][/] | "
-        f"[dark_cyan][link={__issues__}]{__issues__}[/][/]"
-    )
-except ImportError as e:
-    logger.warning("Unable to import rich_argparse: %s\nReverting to argparse", e.msg)
-    from argparse import ArgumentDefaultsHelpFormatter
 
-    __version__, __repository__, __issues__ = ("", "", "")
-    epilog = ""
+epilog = (
+    f"[grey50]Version {__version__}[/] | "
+    f"[dark_cyan][link={__repository__}]{__repository__}[/][/] | "
+    f"[dark_cyan][link={__issues__}]{__issues__}[/][/]"
+)
+
 
 # TODO: ORIGINALLY PART OF INFO
 # examples = """

--- a/src/jockey/__args__.py
+++ b/src/jockey/__args__.py
@@ -2,12 +2,12 @@ from argparse import SUPPRESS, ArgumentParser, FileType, Namespace
 from logging import getLogger
 from typing import Optional, Sequence
 
-
-logger = getLogger(__name__)
-
 from rich_argparse import ArgumentDefaultsRichHelpFormatter as ArgumentDefaultsHelpFormatter
 
 from jockey import __issues__, __repository__, __version__
+
+
+logger = getLogger(__name__)
 
 
 epilog = (

--- a/src/jockey/__main__.py
+++ b/src/jockey/__main__.py
@@ -5,7 +5,7 @@ import os
 import sys
 from typing import Dict, List, Optional, Sequence
 
-from dotty_dict import dotty
+from dotty_dictionary import dotty  # type: ignore[import-untyped]
 from orjson import loads as json_loads
 from rich import print
 from rich.console import Console

--- a/src/jockey/abstractions.py
+++ b/src/jockey/abstractions.py
@@ -31,19 +31,19 @@ class OrderingComparable(Protocol):
     """
 
     @abstractmethod
-    def __lt__(self, other: "O_C") -> bool:
+    def __lt__(self, other: object) -> bool:
         pass
 
     @abstractmethod
-    def __gt__(self, other: "O_C") -> bool:
+    def __gt__(self, other: object) -> bool:
         pass
 
     @abstractmethod
-    def __le__(self, other: "O_C") -> bool:
+    def __le__(self, other: object) -> bool:
         pass
 
     @abstractmethod
-    def __ge__(self, other: "O_C") -> bool:
+    def __ge__(self, other: object) -> bool:
         pass
 
     @staticmethod
@@ -71,11 +71,11 @@ class EqualityComparable(Protocol):
     """
 
     @abstractmethod
-    def __eq__(self, other: "E_C") -> bool:
+    def __eq__(self, other: object) -> bool:
         pass
 
     @abstractmethod
-    def __ne__(self, other: "E_C") -> bool:
+    def __ne__(self, other: object) -> bool:
         pass
 
     @staticmethod

--- a/src/jockey/cache.py
+++ b/src/jockey/cache.py
@@ -44,7 +44,7 @@ from typing import Any, Callable, NamedTuple, Optional
 from orjson import dumps as json_dumps
 from orjson import loads as json_loads
 from slugify import slugify
-from xdgenvpy import XDGPedanticPackage
+from xdgenvpy import XDGPedanticPackage  # type: ignore[import-untyped]
 
 
 JOCKEY_XDG = XDGPedanticPackage("jockey")

--- a/src/jockey/cloud.py
+++ b/src/jockey/cloud.py
@@ -6,12 +6,12 @@ from shlex import quote as shell_quote
 from textwrap import dedent
 from typing import Any, Dict, NamedTuple, Optional, Union
 
-from fabric import Config as FabricConfig
-from fabric import Connection
-from fabric import Result as FabricResult
-from invoke import Config as InvokeConfig
-from invoke import Context
-from invoke import Result as InvokeResult
+from fabric import Config as FabricConfig  # type: ignore[import-untyped]
+from fabric import Connection  # type: ignore[import-untyped]
+from fabric import Result as FabricResult  # type: ignore[import-untyped]
+from invoke import Config as InvokeConfig  # type: ignore[import-untyped]
+from invoke import Context  # type: ignore[import-untyped]
+from invoke import Result as InvokeResult  # type: ignore[import-untyped]
 from orjson import loads as json_loads
 from paramiko.ssh_exception import PasswordRequiredException
 
@@ -193,7 +193,7 @@ class Cloud(Connection, Context):
         return kwargs
 
     def __str__(self) -> str:
-        return "localhost" if self.localhost else self.host
+        return ("localhost" if self.localhost else self.host) or "unknown"
 
     @staticmethod
     def model_reference(controller: str, model: str) -> str:

--- a/src/jockey/filters.py
+++ b/src/jockey/filters.py
@@ -2,9 +2,9 @@ from dataclasses import astuple, dataclass
 from enum import Enum
 from functools import wraps
 from logging import getLogger
-from typing import Any, Callable, Dict, Iterable, Type
+from typing import Any, Callable, Dict, Iterable
 
-from dotty_dict import dotty
+from dotty_dictionary import dotty  # type: ignore[import-untyped]
 from regex import regex
 
 from jockey.abstractions import C_C, E_C, O_C, OE_C, C, T, uses_typevar_params
@@ -261,11 +261,11 @@ def bool_type_parser(value: str) -> bool:
     return value.lower() in {"true", "t", "1", "yes", "y"}
 
 
-TYPE_PARSERS: Dict[Type[T], Callable[[str], T]] = {bool: bool_type_parser}
+TYPE_PARSERS: dict[type, Callable[[str], Any]] = {bool: bool_type_parser}
 """An override map between types and their corresponding parser functions."""
 
 
-def type_parser_for(t: Type[T]) -> Callable[[str], T]:
+def type_parser_for(t: type[T]) -> Callable[[str], T]:
     """
     Returns the appropriate parser function for the given type.
 

--- a/src/jockey/objects.py
+++ b/src/jockey/objects.py
@@ -20,13 +20,13 @@ Examples
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Callable, Iterable, Optional
+from typing import Any, Callable, Iterable, Optional
 
 from jockey.juju import all_applications, all_machines, all_units
 from jockey.juju_schema.full_status import FullStatus
 
 
-ObjectCollector = Callable[[FullStatus], Iterable[dict]]
+ObjectCollector = Callable[[FullStatus], Iterable[Any]]
 """A type alias representing a function that collects objects from the Juju :class:`full_status.FullStatus`."""
 
 
@@ -101,7 +101,7 @@ class Object(Enum):
         raise ValueError(f"Unknown object name '{obj_name}'")
 
     @staticmethod
-    def parse(obj_expression: str) -> ("Object", Optional[str]):
+    def parse(obj_expression: str) -> tuple["Object", Optional[str]]:
         """
         Parses an object expression into its corresponding :class:`Object` and an optional field reference.
 


### PR DESCRIPTION
## Description
Fixes problems with typing such that `mypy` passes.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security fix

## Testing
Ran `mypy` successfully:

`poetry run mypy src`
```
Success: no issues found in 11 source files
```

## Impact
No observable impact to the user. An additional development tool is now available and passing.

## Checklist
- [x] I have documented my code with docstrings and comments, particularly in hard-to-understand areas.
- [x] My changes adhere to the coding and style guidelines of the project and pass linting.
- [x] My changes generate no new warnings.
