### PR TITLE
Fix #58, display a better message on bad object args

### DIFF
--- a/src/jockey/__main__.py
+++ b/src/jockey/__main__.py
@@ -87,9 +87,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     # check if OBJECT is requesting the informational message
     # TODO: BRING BACK INFO MESSAGE
 
-    # parse the OBJECT expression into its components (object, field)
-    obj, obj_field = Object.parse(args.object)
-    logger.debug("Parsed object expression %r into %r with field %r", obj_expression, obj, obj_field)
+    # try parsing the OBJECT expression into its components (object, field)
+    try:
+        obj, obj_field = Object.parse(args.object)
+        logger.debug("Parsed object expression %r into %r with field %r", obj_expression, obj, obj_field)
+    except ValueError as e:
+        logger.error("Unable to parse object expression: %s\nValid options: %s", e, Object.names())
+        return 2  # usage error
 
     # obtain the Juju status
     if "file" in args:  # obtain the Juju status from the provided file

--- a/src/jockey/objects.py
+++ b/src/jockey/objects.py
@@ -83,6 +83,15 @@ class Object(Enum):
         return set(token for obj in Object for token in obj.value.names)
 
     @staticmethod
+    def names() -> set[str]:
+        """
+        Retrieves all names associated with the defined Juju object types.
+
+        :return: A set of all names associated with the Juju object types.
+        """
+        return set(str(obj) for obj in Object)
+
+    @staticmethod
     def from_str(obj_name: str) -> "Object":
         """
         Converts a string representation of a Juju object type into its corresponding :class:`Object`.


### PR DESCRIPTION
## Description
Replace the ugly stack trace for bad object arguments with a helpful message.

![image](https://github.com/user-attachments/assets/65fcc418-e73b-4307-9eed-68717bbb7f48)


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security fix

## Testing
Standard tests and attempted bad argument in bug #58.


## Impact
Displays a helpful error message using the logging facility rather than a gigantic stacktrace.

## Checklist
- [x] I have documented my code with docstrings and comments, particularly in hard-to-understand areas.
- [x] My changes adhere to the coding and style guidelines of the project and pass linting.
- [x] My changes generate no new warnings.
