### PR TITLE
Fix CI for Sphinx docs by using `source` over `poetry shell`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run Sphinx
         shell: bash
         run: |
-          poetry shell
+          source $(poetry env info)/bin/activate
           make -C docs html
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Description
Attempts to fix an `ioctl` error in the CI for generating docs by moving the drop into a virtual environment over to `source` rather than `poetry shell`.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [x] Documentation update
- [ ] Refactoring
- [x] Hotfix
- [ ] Security fix

## Testing
Unable.

## Impact
No impact. Repository CI only.

