### PR TITLE
Add anti-ReDoS tests for filters

### DIFF
--- a/src/jockey/filters.py
+++ b/src/jockey/filters.py
@@ -88,8 +88,13 @@ def regex_filter(value: str, query: str) -> bool:
     :param value: The value to compare.
     :param query: The regular expression query to match against.
     :return: True if the value matches the query, otherwise False.
+    :raises TimeoutError: If :obj:`REGEX_TIMEOUT` is exceeded.
     """
-    return regex.search(str(query), str(value), flags=REGEX_FLAGS, timeout=REGEX_TIMEOUT) is not None
+    try:
+        return regex.search(str(query), str(value), flags=REGEX_FLAGS, timeout=REGEX_TIMEOUT) is not None
+    except TimeoutError as e:
+        logger.warning("Encountered timeout on %r regex %r: %s", value, query, e)
+        raise e
 
 
 @log_filter_action
@@ -100,8 +105,13 @@ def not_regex_filter(value: str, query: str) -> bool:
     :param value: The value to compare.
     :param query: The regular expression query to match against.
     :return: True if the value does not match the query, otherwise False.
+    :raises TimeoutError: If :obj:`REGEX_TIMEOUT` is exceeded.
     """
-    return regex.search(str(query), str(value), flags=REGEX_FLAGS, timeout=REGEX_TIMEOUT) is None
+    try:
+        return regex.search(str(query), str(value), flags=REGEX_FLAGS, timeout=REGEX_TIMEOUT) is None
+    except TimeoutError as e:
+        logger.warning("Encountered timeout on %r not_regex %r: %s", value, query, e)
+        raise e
 
 
 @log_filter_action

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -132,6 +132,20 @@ def test_not_regex_filter(value: str, query: str, want: bool):
     assert not_regex_filter(value, query) == want
 
 
+@pytest.mark.timeout(1)
+def test_regex_filter_anti_redos():
+    with pytest.raises(TimeoutError):
+        with patch("jockey.filters.REGEX_TIMEOUT", 0.00001):
+            regex_filter("a" * 1000 + "b" + "a" * 1000, r"(a|aa)+")
+
+
+@pytest.mark.timeout(1)
+def test_not_regex_filter_anti_redos():
+    with pytest.raises(TimeoutError):
+        with patch("jockey.filters.REGEX_TIMEOUT", 0.00001):
+            not_regex_filter("a" * 1000 + "b" + "a" * 1000, r"(a|aa)+")
+
+
 @pytest.mark.parametrize(
     "value, query, want",
     [


### PR DESCRIPTION
## Description
Adds tests for anti-ReDoS regular expression timeouts.

## Impact
Increases coverage over long-running user-provided regular expressions that may cause a locked-up program.

## Checklist
- [x] I have documented my code with docstrings and comments, particularly in hard-to-understand areas.
- [x] My changes adhere to the coding and style guidelines of the project and pass linting.
- [x] My changes generate no new warnings.
