### PR TITLE
Limit CI paths to Python-related files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     - '**.pyi'
     - pyproject.toml
     - poetry.lock
+    - .github/workflows/*.yml  # workflow changes
   push:
     branches: [master]
     paths:
@@ -14,6 +15,7 @@ on:
     - '**.pyi'
     - pyproject.toml
     - poetry.lock
+    - .github/workflows/*.yml  # workflow changes
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,18 @@ name: CI
 
 on:
   pull_request:
+    paths:
+    - '**.py'
+    - '**.pyi'
+    - pyproject.toml
+    - poetry.lock
   push:
     branches: [master]
+    paths:
+    - '**.py'
+    - '**.pyi'
+    - pyproject.toml
+    - poetry.lock
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Description
This PR limits continuous integration to only run with changes to Python files.
This prevents unnecessary CI runs when, for example, only Markdown is changed.

I keep forgetting `[no ci]` on documentation changes...

## Type of Change
- [x] New feature

## Impact
CI only runs for changes to CI or Python files in PRs now.

## Checklist
- [x] I have documented my code with docstrings and comments, particularly in hard-to-understand areas.
- [x] My changes adhere to the coding and style guidelines of the project and pass linting.
- [x] My changes generate no new warnings.
