### PR TITLE
Fix #73 add `uses` to Install Python

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
         git config user.name "${{ env.BOT_NAME }}"
         git config user.email "${{ env.BOT_EMAIL }}"
     - name: Install Python toolchain
+      uses: actions/setup-python@v5
       with:
         python-version-file: .python-version
     - name: Install git-chglog
@@ -124,7 +125,8 @@ jobs:
       run: |
         ./git-chglog --template .chglog/RELEASE.tpl.md --output CHANGELOG-incremental.md ${{ env.new_tag }}
         cat CHANGELOG-incremental.md
-    - uses: actions/upload-artifact@v4
+    - name: Upload CHANGELOG-incremental
+      uses: actions/upload-artifact@v4
       with:
         name: CHANGELOG-incremental
         path: CHANGELOG-incremental.md


### PR DESCRIPTION
## Description
Fixes missing `uses` in the Release CI workflow.

## Type of Change
- [x] Bug fix
- [x] Hotfix

## Checklist
- [x] I have documented my code with docstrings and comments, particularly in hard-to-understand areas.
- [x] My changes adhere to the coding and style guidelines of the project and pass linting.
- [x] My changes generate no new warnings.
