### PR TITLE
Implement multi-field semantics

### DIFF
--- a/src/jockey/__main__.py
+++ b/src/jockey/__main__.py
@@ -97,8 +97,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     # try parsing the OBJECT expression into its components (object, field)
     try:
-        obj, obj_field = Object.parse(args.object)
-        logger.debug("Parsed object expression %r into %r with field %r", obj_expression, obj, obj_field)
+        obj, obj_fields = Object.parse(args.object)
+        logger.debug("Parsed object expression %r into %r with fields %r", obj_expression, obj, obj_fields)
     except ValueError as e:
         logger.error("Unable to parse object expression: %s\nValid options: %s", e, Object.names())
         return 2  # usage error
@@ -155,12 +155,17 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 selection.append(item)
 
     for item in selection:
-        if obj_field is None:
+        if obj_fields is None:
             print(item["name"])
-        elif obj_field == "":
-            print(item)
+        elif len(obj_fields) == 1:
+            if obj_fields[0] == "":
+                print(item)
+            else:
+                print(Dotty(item, mapping_types=(dict, Application, Unit, Machine))[obj_fields[0]])
         else:
-            print(Dotty(item, mapping_types=(dict, Application, Unit, Machine))[obj_field])
+            print(
+                [Dotty(item, mapping_types=(dict, Application, Unit, Machine))[obj_field] for obj_field in obj_fields]
+            )
 
     return 0
 

--- a/src/jockey/objects.py
+++ b/src/jockey/objects.py
@@ -98,7 +98,7 @@ class Object(Enum):
         raise ValueError(f"Unknown object name '{obj_name}'")
 
     @staticmethod
-    def parse(obj_expression: str) -> tuple["Object", Optional[str]]:
+    def parse(obj_expression: str) -> tuple["Object", Optional[list[str]]]:
         """
         Parses an object expression into its corresponding :class:`Object` and an optional field reference.
 
@@ -107,12 +107,21 @@ class Object(Enum):
         :raises ValueError: If the string does not match any known :class:`Object`, from :func:`from_str`.
         """
         if "." in obj_expression:
-            obj_name, obj_field = obj_expression.split(".", 1)
+            # split on the first dot
+            obj_name, obj_fields_expression = obj_expression.split(".", 1)
         else:
-            obj_name = obj_expression
-            obj_field = None
+            # split on the first comma
+            parts = obj_expression.split(",", 1)
+            obj_name = parts[0]
+            obj_fields_expression = parts[1] if len(parts) > 1 else None
 
-        return Object.from_str(obj_name), obj_field
+        # if fields are specified, split them on the comma boundary into a set
+        if obj_fields_expression:
+            obj_fields = obj_fields_expression.split(",")
+        else:
+            obj_fields = None
+
+        return Object.from_str(obj_name), obj_fields
 
     def collect(self, status: FullStatus) -> list[dict]:
         """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,6 +59,20 @@ CASES = [
         """,
         0,
     ),
+    Case(
+        ["-f", K8S_SAMPLE_PATH, "app,base", "charm=kubernetes-control-plane"],
+        """
+        {'name': 'ubuntu', 'channel': '22.04'}
+        """,
+        0,
+    ),
+    Case(
+        ["-f", K8S_SAMPLE_PATH, "app.name,base", "charm=kubernetes-control-plane"],
+        """
+        ['kubernetes-control-plane', {'name': 'ubuntu', 'channel': '22.04'}]
+        """,
+        0,
+    ),
 ]
 
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -2,6 +2,7 @@
 import os
 import random
 from string import ascii_letters, digits
+from typing import Optional
 
 from orjson import loads as json_loads
 import pytest
@@ -91,18 +92,18 @@ def test_object_from_str_bad_name():
 @pytest.mark.parametrize(
     "string, want_obj, want_field",
     [
-        ("apps.field", Object.APPLICATION, "field"),
-        ("units.field", Object.UNIT, "field"),
-        ("machines.field", Object.MACHINE, "field"),
-        ("a.field.sub", Object.APPLICATION, "field.sub"),
-        ("u.field.sub", Object.UNIT, "field.sub"),
-        ("m.field.sub", Object.MACHINE, "field.sub"),
+        ("apps.field", Object.APPLICATION, ["field"]),
+        ("units.field", Object.UNIT, ["field"]),
+        ("machines.field", Object.MACHINE, ["field"]),
+        ("a.field.sub", Object.APPLICATION, ["field.sub"]),
+        ("u.field.sub", Object.UNIT, ["field.sub"]),
+        ("m.field.sub", Object.MACHINE, ["field.sub"]),
         ("app", Object.APPLICATION, None),
         ("unit", Object.UNIT, None),
         ("machine", Object.MACHINE, None),
     ],
 )
-def test_object_parse(string: str, want_obj: Object, want_field: str):
+def test_object_parse(string: str, want_obj: Object, want_field: Optional[list[str]]):
     assert Object.parse(string) == (want_obj, want_field)
 
 


### PR DESCRIPTION
## Description
This PR implements multi-field semantics as described in #4.

## Type of Change
- [x] New feature

## Testing
Added new CLI tests per TDD.

## Impact
Original behavior works; however, it is possible to select multiple specific fields:

`juju-jockey -f tests/samples/k8s-core-juju-status.json app.name,base charm=kubernetes-control-plane`
```
['kubernetes-control-plane', {'name': 'ubuntu', 'channel': '22.04'}]
```

## Checklist
- [x] I have documented my code with docstrings and comments, particularly in hard-to-understand areas.
- [x] My changes adhere to the coding and style guidelines of the project and pass linting.
- [x] My changes generate no new warnings.
