### PR TITLE
Added containers to machine queries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires-python = ">=3.10"
 
 [tool.poetry]
 name = "jockey"
-version = "0.2.0"
+version = "0.2.1"
 description = "A CLI tool designed to facilitate quick and easy retrieval of Juju objects using filters."
 readme = "README.md"
 authors = [

--- a/src/jockey/juju.py
+++ b/src/jockey/juju.py
@@ -48,7 +48,7 @@ class Wrapper(Mapping):
         if key == "@status":
             return self.juju_status
 
-        return self.status[key]
+        return self.status.get(key, None)
 
     def __setitem__(self, key, value):
         if key == "name" or key == "@name" or key in self.tokens:
@@ -350,6 +350,9 @@ class Machine(Wrapper):
         if "machines" in juju_status:
             for name in juju_status["machines"]:
                 yield Machine(juju_status, name)
+
+                for container in juju_status["machines"][name].get("containers", []):
+                    yield Machine(juju_status, container)
 
     @staticmethod
     def id_is_container(machine_name: str) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,6 +55,7 @@ CASES = [
         ],
         """
         arch=amd64 cores=2 mem=8192M virt-type=container
+        None
         arch=amd64 cores=2 mem=8192M virt-type=container
         """,
         0,

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -133,7 +133,7 @@ def test_object_parse_bad_name():
                 "containerd/0",
             },
         ),
-        ("k8s-core-juju-status.json", Object.MACHINE, {"0", "1"}),
+        ("k8s-core-juju-status.json", Object.MACHINE, {"0", "0/lxd/0", "1"}),
     ],
 )
 def test_object_collect(obj: Object, sample: str, names: set[str]):


### PR DESCRIPTION
Containers are now properly listed in `juju-jockey machines`.  

Closes #97 

## Description

Containers are listed under non-container physical machines in `juju status --format json`, which was not considered in the previous implementation.  Now, after each physical `Machine` object is created, if the `"containers"` key is detected, each container found there is also yielded as a `Machine`.  

This change required that container `Machines` have a `"hardware"` value to pass testing.  For now, containers are given a default `None` value.  

Existing unit tests have been updated to include these changes.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security fix

## Checklist
- [x] I have documented my code with docstrings and comments, particularly in hard-to-understand areas.
- [x] My changes adhere to the coding and style guidelines of the project and pass linting.
- [x] My changes generate no new warnings.
